### PR TITLE
Adds code to distribute the utility as a docker image

### DIFF
--- a/DOCKER.md
+++ b/DOCKER.md
@@ -1,0 +1,61 @@
+# Supported tags and respective `Dockerfile` links
+
+-	[`und-5.0.950`, `latest`, (*Dockerfile*)](https://github.com/sglebs/srccheck/Dockerfile)
+
+## How to use this image
+
+* Using srccheck utilities:
+
+```bash
+docker run --rm -it -v "${PWD}:/project" -w "/project" sglebs/srccheck
+```
+
+* [SciTools Understand][] command lines utility can also be used directly:
+
+```bash
+docker run --rm -it -v "${PWD}:/project" -w "/project" sglebs/srccheck und help
+```
+
+* If your docker host provides a [X Window System][], [SciTools Understand][] can be executed in *GUI* mode. You'll need [display access][] to the user that's running the command:
+
+```bash
+docker run --rm -it -e DISPLAY="${DISPLAY}" -v "${PWD}:/project" -w "/project" -v "/tmp/.X11-unix:/tmp/.X11-unix" sglebs/understand understand
+```
+
+## Environment variables
+
+Below a list of [environment variables](https://docs.docker.com/engine/reference/run/#env-environment-variables) that can be used to configure this image execution:
+
+| Name | Description | Default value |
+|---|---|---|
+| EVALCODE | Evaluation license code provided to run [SciTools Understand][] | - |
+| SDLCODE | Single developer license code provided to run [SciTools Understand][]. `USER_EMAIL_ACCOUNT` must be also provided to enable this activation method | - |
+| USER_EMAIL_ACCOUNT | User email account associated with `SDL` license used to activate [SciTools Understand][]. `SDLCODE` must be also provided to enable this activation method | - |
+| FLOATING_LICENSE_SERVER | Address used to connect [SciTools Understand][] client to a license server | - |
+| FLOATING_LICENSE_SERVER_PORT | Port used to connect [SciTools Understand][] client to a license server. `FLOATING_LICENSE_SERVER` must be also provided to enable this activation method | 9000 |
+
+## License
+
+Since [SciTools Understand][] is bundled, it must be [activated][]. This image provides a few methods to achieve that (check the section above). If you have any doubts regarding [Scitools Understand][] licensing, please read their [end user license agreement][].
+
+Also, since the first execution saves activation information in `~/.config/SciTools` (check the [Dockerfile](https://github.com/sglebs/srccheck/Dockerfile)), it's recommended to create a [docker volume][] to persist user data between executions. Below an example when using `FLOATING_LICENSE_SERVER` activation method:
+
+* Creating the volume:
+
+```bash
+docker volume create und-data
+```
+
+* Running:
+
+```bash
+docker run --rm -it -e FLOATING_LICENSE_SERVER="license_server_host" -v "und-data:/root/.config/SciTools" -v "${PWD}:/project" -w "/project" sglebs/srccheck
+```
+
+[X Window System]: https://en.wikipedia.org/wiki/X_Window_System
+[display access]: https://askubuntu.com/questions/654966/enable-x-display-access-for-local-user
+[activated]: https://scitools.com/support/running-understand-headless-linux-server/
+[end user license agreement]: https://scitools.com/eula/
+[environment variables]: https://docs.docker.com/engine/reference/run/#env-environment-variables
+[SciTools Understand]: https://scitools.com/features/
+[docker volume]: https://docs.docker.com/engine/reference/commandline/volume_create/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,31 @@
+FROM python:3.6-jessie
+
+WORKDIR /data
+
+COPY requirements.txt *.py /data/
+ADD utilities /data/utilities
+
+ENV UNDERSTAND_FILE="Understand-5.0.950-Linux-64bit.tgz" \
+    UNDERSTAND_HOME="/data/scitools"
+
+ENV UNDERSTAND_REPO_URL="http://latest.scitools.com/Understand/${UNDERSTAND_FILE}" \
+    PYTHONPATH="${UNDERSTAND_HOME}/bin/linux64/python" \
+    UNDERSTAND_USER_HOME="/root/.config/SciTools" \
+    PATH="${PATH}:${UNDERSTAND_HOME}/bin/linux64/"
+
+
+RUN apt-get update \
+    && apt-get install -y curl tar libqt5gui5 \
+    && curl -s -O "${UNDERSTAND_REPO_URL}" \
+    && tar xvf "${UNDERSTAND_FILE}" \
+    && rm -rf "${UNDERSTAND_FILE}" \
+    && pip install --upgrade pip \
+    && pip install paver \
+    && pip install -r requirements.txt
+
+VOLUME "${UNDERSTAND_USER_HOME}"
+
+COPY docker-entrypoint.sh /data/
+
+ENTRYPOINT [ "./docker-entrypoint.sh" ]
+CMD [ "srccheck" ]

--- a/README.md
+++ b/README.md
@@ -72,8 +72,6 @@ Under Linux, some users reported that you need to install some libraries before 
  * Ubuntu: sudo apt-get install python3-tk
  * CentOS: yum install python3-tkinter
 
-
-
 How to Upgrade srccheck
 =======================
 
@@ -93,6 +91,9 @@ pyinstaller --exclude-module understand -F utilities/srccheck.py
 
 Now your *dist* directory should have a standalone native executable which you can copy to a different machine.
 
+Docker Image
+============
+This utility is also provided as a [Docker image](https://hub.docker.com/r/sglebs/srccheck). Usage documentation can be accessed [here](DOCKER.md).
 
 How to Run It
 =============

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+if [ ! -d "${UNDERSTAND_HOME}" ]; then
+    mkdir -p "${UNDERSTAND_HOME}"
+fi
+
+if [ ! -z "${FLOATING_LICENSE_SERVER}" ]; then
+    if [ -z "${FLOATING_LICENSE_SERVER_PORT}" ];then
+        FLOATING_LICENSE_SERVER_PORT="9000"
+    fi
+    echo "Connecting to floating license server: ${FLOATING_LICENSE_SERVER}:${FLOATING_LICENSE_SERVER_PORT}"
+    echo "${FLOATING_LICENSE_SERVER} 00000000 ${FLOATING_LICENSE_SERVER_PORT}" > "${UNDERSTAND_HOME}/conf/license/locallicense.dat"
+fi
+
+if [[ ! -z "${SDLCODE}" && ! -z "${USER_EMAIL_ACCOUNT}" ]] ; then
+    echo "${USER} ${SDLCODE}" > "${UNDERSTAND_HOME}/conf/license/users.txt"
+    UNDERSTAND_USER_CFG="${UNDERSTAND_USER_HOME}/Understand.conf"
+    if [ ! -f "${UNDERSTAND_USER_CFG}" ]; then
+        echo "Using SDL license registered to account \"${USER_EMAIL_ACCOUNT}\": ${SDLCODE}"
+        echo "[General]" > "${UNDERSTAND_USER_CFG}"
+        echo "UserText=${USER_EMAIL_ACCOUNT}" >> "${UNDERSTAND_USER_CFG}"
+    fi
+fi
+
+if [ ! -z "${EVALCODE}" ]; then
+    echo "Using evaluation code: ${EVALCODE}"
+    echo "${USER} ${EVALCODE}" > "${UNDERSTAND_HOME}/conf/license/users.txt"
+fi
+
+exec "${@}"


### PR DESCRIPTION
This commit addresses the request to distribute the utility as a docker
image (resolves #62). `Dockerfile` and `entrypoint` files added, as well as
documentation describing how to use this image.