### PR TITLE
Updates Understand version and repo URL

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ ENV UNDERSTAND_VERSION="5.0" \
 ENV UNDERSTAND_FILE="Understand-${UNDERSTAND_VERSION}.${UNDERSTAND_BUILD}-Linux-64bit.tgz"
 
 ENV UNDERSTAND_REPO_URL="http://builds.scitools.com/all_builds/b${UNDERSTAND_BUILD}/Understand/${UNDERSTAND_FILE}" \
-    PYTHONPATH="${UNDERSTAND_HOME}/bin/linux64/python" \
+    PYTHONPATH="${UNDERSTAND_HOME}/bin/linux64/Python" \
     UNDERSTAND_USER_HOME="/root/.config/SciTools" \
     PATH="${PATH}:${UNDERSTAND_HOME}/bin/linux64/"
 
@@ -30,5 +30,5 @@ VOLUME "${UNDERSTAND_USER_HOME}"
 
 COPY docker-entrypoint.sh /data/
 
-ENTRYPOINT [ "./docker-entrypoint.sh" ]
+ENTRYPOINT [ "/data/docker-entrypoint.sh" ]
 CMD [ "srccheck" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,10 +5,13 @@ WORKDIR /data
 COPY requirements.txt *.py /data/
 ADD utilities /data/utilities
 
-ENV UNDERSTAND_FILE="Understand-5.0.950-Linux-64bit.tgz" \
+ENV UNDERSTAND_VERSION="5.0" \
+    UNDERSTAND_BUILD="953" \
     UNDERSTAND_HOME="/data/scitools"
 
-ENV UNDERSTAND_REPO_URL="http://latest.scitools.com/Understand/${UNDERSTAND_FILE}" \
+ENV UNDERSTAND_FILE="Understand-${UNDERSTAND_VERSION}.${UNDERSTAND_BUILD}-Linux-64bit.tgz"
+
+ENV UNDERSTAND_REPO_URL="http://builds.scitools.com/all_builds/b${UNDERSTAND_BUILD}/Understand/${UNDERSTAND_FILE}" \
     PYTHONPATH="${UNDERSTAND_HOME}/bin/linux64/python" \
     UNDERSTAND_USER_HOME="/root/.config/SciTools" \
     PATH="${PATH}:${UNDERSTAND_HOME}/bin/linux64/"


### PR DESCRIPTION
Changes `UNDERSTAND_REPO_URL` to the one containing all build versions.
Dockerfile had to be changed to use this new URL.

Additionally, Scitools Understand version updated to b953

Resolves #65